### PR TITLE
Support glob patterns in `open_datatree(group=...)` for selective group loading

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1097,8 +1097,12 @@ def open_datatree(
         Additional keyword arguments passed on to the engine open function.
         For example:
 
-        - 'group': path to the group in the given file to open as the root group as
-          a str.
+        - 'group': path to the group in the given file to open as the root
+          group as a str.  If the string contains glob metacharacters
+          (``*``, ``?``, ``[``), it is interpreted as a pattern and only
+          groups whose paths match are loaded (along with their ancestors).
+          For example, ``group="*/sweep_0"`` loads every ``sweep_0`` one
+          level deep while skipping sibling groups.
         - 'lock': resource lock to use when reading data from disk. Only
           relevant when using dask or another form of parallelism. By default,
           appropriate locks are chosen to safely read and write files with the
@@ -1344,8 +1348,12 @@ def open_groups(
         Additional keyword arguments passed on to the engine open function.
         For example:
 
-        - 'group': path to the group in the given file to open as the root group as
-          a str.
+        - 'group': path to the group in the given file to open as the root
+          group as a str.  If the string contains glob metacharacters
+          (``*``, ``?``, ``[``), it is interpreted as a pattern and only
+          groups whose paths match are loaded (along with their ancestors).
+          For example, ``group="*/sweep_0"`` loads every ``sweep_0`` one
+          level deep while skipping sibling groups.
         - 'lock': resource lock to use when reading data from disk. Only
           relevant when using dask or another form of parallelism. By default,
           appropriate locks are chosen to safely read and write files with the

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -245,6 +245,37 @@ def _iter_nc_groups(root, parent="/"):
         yield from _iter_nc_groups(group, parent=gpath)
 
 
+def _is_glob_pattern(pattern: str) -> bool:
+    return any(c in pattern for c in "*?[")
+
+
+def _filter_group_paths(group_paths: Iterable[str], pattern: str) -> list[str]:
+    from xarray.core.treenode import NodePath
+
+    matched: set[str] = {"/"}
+    for path in group_paths:
+        np_ = NodePath(path)
+        if np_.match(pattern):
+            matched.add(path)
+            for parent in np_.parents:
+                p = str(parent)
+                if p:
+                    matched.add(p)
+
+    return [p for p in group_paths if p in matched]
+
+
+def _resolve_group_and_filter(
+    group: str | None,
+    all_group_paths: list[str],
+) -> tuple[str | None, list[str]]:
+    if group is None:
+        return None, all_group_paths
+    if _is_glob_pattern(group):
+        return None, _filter_group_paths(all_group_paths, group)
+    return group, all_group_paths
+
+
 def find_root_and_group(ds):
     """Find the root and group name of a netCDF4/h5netcdf dataset."""
     hierarchy = ()

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -635,7 +635,11 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         driver_kwds=None,
         **kwargs,
     ) -> dict[str, Dataset]:
-        from xarray.backends.common import _iter_nc_groups
+        from xarray.backends.common import (
+            _is_glob_pattern,
+            _iter_nc_groups,
+            _resolve_group_and_filter,
+        )
         from xarray.core.treenode import NodePath
         from xarray.core.utils import close_on_error
 
@@ -644,10 +648,12 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         emit_phony_dims_warning, phony_dims = _check_phony_dims(phony_dims)
 
         filename_or_obj = _normalize_filename_or_obj(filename_or_obj)
+
+        effective_group = None if (group and _is_glob_pattern(group)) else group
         store = H5NetCDFStore.open(
             filename_or_obj,
             format=format,
-            group=group,
+            group=effective_group,
             lock=lock,
             invalid_netcdf=invalid_netcdf,
             phony_dims=phony_dims,
@@ -656,15 +662,17 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
             driver_kwds=driver_kwds,
         )
 
-        # Check for a group and make it a parent if it exists
-        if group:
-            parent = NodePath("/") / NodePath(group)
+        if effective_group:
+            parent = NodePath("/") / NodePath(effective_group)
         else:
             parent = NodePath("/")
 
         manager = store._manager
+        all_group_paths = list(_iter_nc_groups(store.ds, parent=parent))
+        _, filtered_paths = _resolve_group_and_filter(group, all_group_paths)
+
         groups_dict = {}
-        for path_group in _iter_nc_groups(store.ds, parent=parent):
+        for path_group in filtered_paths:
             group_store = H5NetCDFStore(manager, group=path_group, **kwargs)
             store_entrypoint = StoreBackendEntrypoint()
             with close_on_error(group_store):
@@ -679,7 +687,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
                     decode_timedelta=decode_timedelta,
                 )
 
-            if group:
+            if effective_group:
                 group_name = str(NodePath(path_group).relative_to(parent))
             else:
                 group_name = str(NodePath(path_group))

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -859,13 +859,19 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
         autoclose=False,
         **kwargs,
     ) -> dict[str, Dataset]:
-        from xarray.backends.common import _iter_nc_groups
+        from xarray.backends.common import (
+            _is_glob_pattern,
+            _iter_nc_groups,
+            _resolve_group_and_filter,
+        )
         from xarray.core.treenode import NodePath
 
         filename_or_obj = _normalize_path(filename_or_obj)
+
+        effective_group = None if (group and _is_glob_pattern(group)) else group
         store = NetCDF4DataStore.open(
             filename_or_obj,
-            group=group,
+            group=effective_group,
             format=format,
             clobber=clobber,
             diskless=diskless,
@@ -875,15 +881,17 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
             autoclose=autoclose,
         )
 
-        # Check for a group and make it a parent if it exists
-        if group:
-            parent = NodePath("/") / NodePath(group)
+        if effective_group:
+            parent = NodePath("/") / NodePath(effective_group)
         else:
             parent = NodePath("/")
 
         manager = store._manager
+        all_group_paths = list(_iter_nc_groups(store.ds, parent=parent))
+        _, filtered_paths = _resolve_group_and_filter(group, all_group_paths)
+
         groups_dict = {}
-        for path_group in _iter_nc_groups(store.ds, parent=parent):
+        for path_group in filtered_paths:
             group_store = NetCDF4DataStore(manager, group=path_group, **kwargs)
             store_entrypoint = StoreBackendEntrypoint()
             with close_on_error(group_store):
@@ -897,7 +905,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
                     use_cftime=use_cftime,
                     decode_timedelta=decode_timedelta,
                 )
-            if group:
+            if effective_group:
                 group_name = str(NodePath(path_group).relative_to(parent))
             else:
                 group_name = str(NodePath(path_group))

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1900,10 +1900,13 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         zarr_format=None,
         max_concurrency: int | None = None,
     ) -> DataTree:
+        from xarray.backends.common import _is_glob_pattern, _resolve_group_and_filter
+
         filename_or_obj = _normalize_path(filename_or_obj)
 
-        if group:
-            parent = str(NodePath("/") / NodePath(group))
+        effective_group = None if (group and _is_glob_pattern(group)) else group
+        if effective_group:
+            parent = str(NodePath("/") / NodePath(effective_group))
         else:
             parent = str(NodePath("/"))
 
@@ -1964,8 +1967,11 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                 zarr_version=zarr_version,
                 zarr_format=zarr_format,
             )
+            all_paths = list(stores.keys())
+            _, filtered_paths = _resolve_group_and_filter(group, all_paths)
             groups_dict = {}
-            for path_group, store in stores.items():
+            for path_group in filtered_paths:
+                store = stores[path_group]
                 store_entrypoint = StoreBackendEntrypoint()
                 with close_on_error(store):
                     group_ds = store_entrypoint.open_dataset(
@@ -1978,7 +1984,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                         use_cftime=use_cftime,
                         decode_timedelta=decode_timedelta,
                     )
-                if group:
+                if effective_group:
                     group_name = str(NodePath(path_group).relative_to(parent))
                 else:
                     group_name = str(NodePath(path_group))
@@ -2045,6 +2051,16 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
             if parent_path in group_children:
                 group_children[parent_path][child_name] = member
 
+        # Filter groups when glob pattern is used
+        from xarray.backends.common import _resolve_group_and_filter
+
+        effective_group, filtered_paths = _resolve_group_and_filter(
+            group, list(group_async.keys())
+        )
+        filtered_set = set(filtered_paths)
+        group_async = {k: v for k, v in group_async.items() if k in filtered_set}
+        group_children = {k: v for k, v in group_children.items() if k in filtered_set}
+
         # Phase 2: Open each group — wrap async objects, run CPU decode in threads.
         async def open_one(path_group: str) -> tuple[str, Dataset]:
             async_grp = group_async[path_group]
@@ -2091,7 +2107,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                     )
 
             ds = await loop.run_in_executor(executor, _cpu_open)
-            if group:
+            if effective_group:
                 group_name = str(NodePath(path_group).relative_to(parent))
             else:
                 group_name = str(NodePath(path_group))
@@ -2132,11 +2148,13 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         zarr_version=None,
         zarr_format=None,
     ) -> dict[str, Dataset]:
+        from xarray.backends.common import _is_glob_pattern, _resolve_group_and_filter
+
         filename_or_obj = _normalize_path(filename_or_obj)
 
-        # Check for a group and make it a parent if it exists
-        if group:
-            parent = str(NodePath("/") / NodePath(group))
+        effective_group = None if (group and _is_glob_pattern(group)) else group
+        if effective_group:
+            parent = str(NodePath("/") / NodePath(effective_group))
         else:
             parent = str(NodePath("/"))
 
@@ -2153,8 +2171,11 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
             zarr_format=zarr_format,
         )
 
+        _, filtered_paths = _resolve_group_and_filter(group, list(stores.keys()))
+
         groups_dict = {}
-        for path_group, store in stores.items():
+        for path_group in filtered_paths:
+            store = stores[path_group]
             store_entrypoint = StoreBackendEntrypoint()
 
             with close_on_error(store):
@@ -2168,7 +2189,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                     use_cftime=use_cftime,
                     decode_timedelta=decode_timedelta,
                 )
-            if group:
+            if effective_group:
                 group_name = str(NodePath(path_group).relative_to(parent))
             else:
                 group_name = str(NodePath(path_group))
@@ -2200,11 +2221,13 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         This mirrors open_groups_as_dict but parallelizes per-group Dataset opening,
         which can significantly reduce latency on high-RTT object stores.
         """
+        from xarray.backends.common import _is_glob_pattern, _resolve_group_and_filter
+
         filename_or_obj = _normalize_path(filename_or_obj)
 
-        # Determine parent group path context
-        if group:
-            parent = str(NodePath("/") / NodePath(group))
+        effective_group = None if (group and _is_glob_pattern(group)) else group
+        if effective_group:
+            parent = str(NodePath("/") / NodePath(effective_group))
         else:
             parent = str(NodePath("/"))
 
@@ -2220,6 +2243,9 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
             zarr_version=zarr_version,
             zarr_format=zarr_format,
         )
+
+        _, filtered_paths = _resolve_group_and_filter(group, list(stores.keys()))
+        filtered_set = set(filtered_paths)
 
         loop = asyncio.get_running_loop()
         max_workers = min(len(stores), 10) if stores else 1
@@ -2244,7 +2270,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                     )
 
             ds = await loop.run_in_executor(executor, _load_sync)
-            if group:
+            if effective_group:
                 group_name = str(NodePath(path_group).relative_to(parent))
             else:
                 group_name = str(NodePath(path_group))
@@ -2252,7 +2278,9 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
         try:
             tasks = [
-                open_one(path_group, store) for path_group, store in stores.items()
+                open_one(path_group, store)
+                for path_group, store in stores.items()
+                if path_group in filtered_set
             ]
             results = await asyncio.gather(*tasks)
         finally:

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -377,6 +377,79 @@ class NetCDFIOBase:
             assert subgroup_tree.root.parent is None
             assert_equal(subgroup_tree, expected_subtree)
 
+    def test_open_datatree_group_glob(self, tmpdir) -> None:
+        original_dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"root_var": 1}),
+                "/A": xr.Dataset({"a_var": 2}),
+                "/A/sweep_0": xr.Dataset({"data": ("x", [1, 2])}),
+                "/A/sweep_1": xr.Dataset({"data": ("x", [3, 4])}),
+                "/B": xr.Dataset({"b_var": 3}),
+                "/B/sweep_0": xr.Dataset({"data": ("x", [5, 6])}),
+            }
+        )
+        filepath = tmpdir / "glob_test.nc"
+        original_dt.to_netcdf(filepath, engine=self.engine)
+
+        with open_datatree(filepath, group="*/sweep_0", engine=self.engine) as tree:
+            paths = {node.path for node in tree.subtree}
+            assert "/A/sweep_0" in paths
+            assert "/B/sweep_0" in paths
+            assert "/A/sweep_1" not in paths
+
+    def test_open_datatree_group_glob_no_match(self, tmpdir) -> None:
+        original_dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"root_var": 1}),
+                "/A": xr.Dataset({"a_var": 2}),
+            }
+        )
+        filepath = tmpdir / "glob_nomatch.nc"
+        original_dt.to_netcdf(filepath, engine=self.engine)
+
+        with open_datatree(filepath, group="*/nonexistent", engine=self.engine) as tree:
+            paths = {node.path for node in tree.subtree}
+            assert paths == {"/"}
+
+    def test_open_datatree_group_glob_preserves_data(self, tmpdir) -> None:
+        original_dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"root_var": 1}),
+                "/A": xr.Dataset({"a_var": 2}),
+                "/A/sweep_0": xr.Dataset({"data": ("x", [1, 2])}),
+            }
+        )
+        filepath = tmpdir / "glob_data.nc"
+        original_dt.to_netcdf(filepath, engine=self.engine)
+
+        with open_datatree(filepath, group="*/sweep_0", engine=self.engine) as tree:
+            assert tree["/A"].dataset["a_var"].item() == 2
+            np.testing.assert_array_equal(
+                tree["/A/sweep_0"].dataset["data"].values, [1, 2]
+            )
+
+    def test_open_groups_group_glob(self, tmpdir) -> None:
+        original_dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"root_var": 1}),
+                "/A": xr.Dataset({"a_var": 2}),
+                "/A/sweep_0": xr.Dataset({"data": ("x", [1, 2])}),
+                "/A/sweep_1": xr.Dataset({"data": ("x", [3, 4])}),
+            }
+        )
+        filepath = tmpdir / "glob_groups.nc"
+        original_dt.to_netcdf(filepath, engine=self.engine)
+
+        groups = open_groups(filepath, group="*/sweep_0", engine=self.engine)
+        try:
+            assert "/" in groups
+            assert "/A" in groups
+            assert "/A/sweep_0" in groups
+            assert "/A/sweep_1" not in groups
+        finally:
+            for ds in groups.values():
+                ds.close()
+
 
 @requires_h5netcdf_or_netCDF4
 class TestGenericNetCDFIO(NetCDFIOBase):
@@ -1017,6 +1090,62 @@ class TestZarrDatatreeIO:
             assert subgroup_tree.root.parent is None
             assert_equal(subgroup_tree, expected_subtree)
 
+    def test_open_datatree_group_glob(self, tmpdir, zarr_format) -> None:
+        original_dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"root_var": 1}),
+                "/A": xr.Dataset({"a_var": 2}),
+                "/A/sweep_0": xr.Dataset({"data": ("x", [1, 2])}),
+                "/A/sweep_1": xr.Dataset({"data": ("x", [3, 4])}),
+                "/B": xr.Dataset({"b_var": 3}),
+                "/B/sweep_0": xr.Dataset({"data": ("x", [5, 6])}),
+            }
+        )
+        filepath = str(tmpdir / "glob_test.zarr")
+        original_dt.to_zarr(filepath, zarr_format=zarr_format)
+
+        with open_datatree(filepath, group="*/sweep_0", engine=self.engine) as tree:
+            paths = {node.path for node in tree.subtree}
+            assert "/A/sweep_0" in paths
+            assert "/B/sweep_0" in paths
+            assert "/A/sweep_1" not in paths
+
+    def test_open_datatree_group_glob_no_match(self, tmpdir, zarr_format) -> None:
+        original_dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"root_var": 1}),
+                "/A": xr.Dataset({"a_var": 2}),
+            }
+        )
+        filepath = str(tmpdir / "glob_nomatch.zarr")
+        original_dt.to_zarr(filepath, zarr_format=zarr_format)
+
+        with open_datatree(filepath, group="*/nonexistent", engine=self.engine) as tree:
+            paths = {node.path for node in tree.subtree}
+            assert paths == {"/"}
+
+    def test_open_groups_group_glob(self, tmpdir, zarr_format) -> None:
+        original_dt = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"root_var": 1}),
+                "/A": xr.Dataset({"a_var": 2}),
+                "/A/sweep_0": xr.Dataset({"data": ("x", [1, 2])}),
+                "/A/sweep_1": xr.Dataset({"data": ("x", [3, 4])}),
+            }
+        )
+        filepath = str(tmpdir / "glob_groups.zarr")
+        original_dt.to_zarr(filepath, zarr_format=zarr_format)
+
+        groups = open_groups(filepath, group="*/sweep_0", engine=self.engine)
+        try:
+            assert "/" in groups
+            assert "/A" in groups
+            assert "/A/sweep_0" in groups
+            assert "/A/sweep_1" not in groups
+        finally:
+            for ds in groups.values():
+                ds.close()
+
     @requires_dask
     def test_open_groups_chunks(self, tmpdir, zarr_format) -> None:
         """Test `open_groups` with chunks on a zarr store."""
@@ -1134,3 +1263,52 @@ class TestZarrDatatreeIO:
 
         with open_datatree(filepath) as roundtrip_dt:
             assert_identical(original_dt, roundtrip_dt)
+
+
+class TestGlobPatternUtilities:
+    def test_is_glob_pattern(self) -> None:
+        from xarray.backends.common import _is_glob_pattern
+
+        assert _is_glob_pattern("*/sweep_0")
+        assert _is_glob_pattern("VCP-34/sweep_[01]")
+        assert _is_glob_pattern("sweep_?")
+        assert not _is_glob_pattern("VCP-34")
+        assert not _is_glob_pattern("/group/subgroup")
+
+    def test_filter_group_paths(self) -> None:
+        from xarray.backends.common import _filter_group_paths
+
+        paths = ["/", "/A", "/A/sweep_0", "/A/sweep_1", "/B", "/B/sweep_0"]
+        result = _filter_group_paths(paths, "*/sweep_0")
+        assert result == ["/", "/A", "/A/sweep_0", "/B", "/B/sweep_0"]
+
+    def test_filter_group_paths_no_match(self) -> None:
+        from xarray.backends.common import _filter_group_paths
+
+        paths = ["/", "/A", "/B"]
+        result = _filter_group_paths(paths, "*/nonexistent")
+        assert result == ["/"]
+
+    def test_resolve_group_and_filter_none(self) -> None:
+        from xarray.backends.common import _resolve_group_and_filter
+
+        paths = ["/", "/A"]
+        effective, filtered = _resolve_group_and_filter(None, paths)
+        assert effective is None
+        assert filtered == paths
+
+    def test_resolve_group_and_filter_literal(self) -> None:
+        from xarray.backends.common import _resolve_group_and_filter
+
+        paths = ["/", "/A"]
+        effective, filtered = _resolve_group_and_filter("A", paths)
+        assert effective == "A"
+        assert filtered == paths
+
+    def test_resolve_group_and_filter_glob(self) -> None:
+        from xarray.backends.common import _resolve_group_and_filter
+
+        paths = ["/", "/A", "/A/sweep_0", "/A/sweep_1", "/B", "/B/sweep_0"]
+        effective, filtered = _resolve_group_and_filter("*/sweep_0", paths)
+        assert effective is None
+        assert filtered == ["/", "/A", "/A/sweep_0", "/B", "/B/sweep_0"]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

When the `group` parameter contains glob metacharacters (`*`, `?`, `[`), filter which groups are opened instead of re-rooting the tree. This avoids loading the entire hierarchy when only a subset is needed — useful for radar data (`*/sweep_0`) and CMIP archives (`*/historical/tas`).

Adds shared utilities `_is_glob_pattern`, `_filter_group_paths`, and `_resolve_group_and_filter` in `common.py`. Updates NetCDF4, H5NetCDF, and Zarr backends to use a discover → filter → open pipeline. Uses the same matching engine as `DataTree.match()`.

- [x] Closes pydata/xarray#11196
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

Stacked on pydata/xarray#10742